### PR TITLE
Check if the client still has connection before calling Send in a try/catch

### DIFF
--- a/Source/Meadow.Logging.LogProviders/Driver/UdpLogger.cs
+++ b/Source/Meadow.Logging.LogProviders/Driver/UdpLogger.cs
@@ -11,10 +11,10 @@ namespace Meadow.Logging
     public class UdpLogger : ILogProvider, IDisposable
     {
         private bool _isDisposed;
-        private int _port;
-        private UdpClient _client;
-        private IPEndPoint _broadcast;
-        private char _delimiter;
+        private readonly int _port;
+        private readonly UdpClient _client;
+        private readonly IPEndPoint _broadcast;
+        private readonly char _delimiter;
 
         /// <summary>
         /// Creates a UdpLogger instance
@@ -33,8 +33,18 @@ namespace Meadow.Logging
         /// <inheritdoc/>
         public void Log(LogLevel level, string message, string? _)
         {
-            var payload = Encoding.UTF8.GetBytes($"{level}{_delimiter}{message}\n");
-            _client.Send(payload, payload.Length, _broadcast);
+            if (_client.Client.Connected)
+            {
+                var payload = Encoding.UTF8.GetBytes($"{level}{_delimiter}{message}\n");
+                try
+                {
+                    _client.Send(payload, payload.Length, _broadcast);
+                }
+                catch 
+                {
+                    // TODO: ignore exceptions ?
+                }
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
The UDP logger needs to check the connection is still valid before calling Send and use try/catch to trap other exceptions to avoid the calling thread getting killed if the network has unexpectedly died or becomes inaccessible. 

This change also marks some properties only initialised in the constructor as `readonly` to show the intent they should not be changed by other parts of the class. 