### PR TITLE
Add Remove method to LogProviderCollection and Logger

### DIFF
--- a/Source/Meadow.Logging/lib/LogProviderCollection.cs
+++ b/Source/Meadow.Logging/lib/LogProviderCollection.cs
@@ -27,6 +27,18 @@ namespace Meadow.Logging
         }
 
         /// <summary>
+        /// Adds a Provider to the collection
+        /// </summary>
+        /// <param name="provider"></param>
+        public bool Remove(ILogProvider provider)
+        {
+            lock (Providers)
+            {
+                return Providers.Remove(provider);
+            }
+        }
+
+        /// <summary>
         /// Gets an Enumerator for the collection
         /// </summary>
         /// <returns></returns>

--- a/Source/Meadow.Logging/lib/Logger.cs
+++ b/Source/Meadow.Logging/lib/Logger.cs
@@ -110,6 +110,18 @@ public class Logger
     }
 
     /// <summary>
+    /// Adds an ILogProvider to the providers collection
+    /// </summary>
+    /// <param name="provider"></param>
+    public bool RemoveProvider(ILogProvider provider)
+    {
+        lock (_providers)
+        {
+            return _providers.Remove(provider);
+        }
+    }
+
+    /// <summary>
     /// Sends a Trace-level message to all ILogProviders
     /// </summary>
     /// <param name="message">The message to send to Providers</param>


### PR DESCRIPTION
Applications should remove UdpLogger from collection when disconnected from the network.
Remove method enables dynamic add/remove of loggers.