### PR TITLE
Add optional port to command line

### DIFF
--- a/Source/Meadow.Logging.LogProviders/Samples/UdpLogClient_Sample/Program.cs
+++ b/Source/Meadow.Logging.LogProviders/Samples/UdpLogClient_Sample/Program.cs
@@ -2,19 +2,34 @@
 using System.Net.Sockets;
 using System.Text;
 
-const int PORT = 5100;
+int port = 5100;
 const char DELIMITER = '\t';
 
 Console.WriteLine("Meadow UDP Log Client");
 
-UdpClient udpClient = new UdpClient();
-udpClient.Client.Bind(new IPEndPoint(IPAddress.Any, PORT));
-
-var from = new IPEndPoint(0, 0);
-while (true)
+if (args.Length > 1 || (args.Length ==1 && !int.TryParse(args[0], out port)))
 {
-    var recvBuffer = udpClient.Receive(ref from);
-    var payload = Encoding.UTF8.GetString(recvBuffer);
-    var parts = payload.Split(new char[] { DELIMITER });
-    Console.WriteLine($"{parts[0]}: {parts[1].Trim()}");
+    Console.WriteLine("Usage: <program> <port>");
+    return;
+}
+
+try
+{
+    Console.WriteLine($"Port: {port}");
+    UdpClient udpClient = new UdpClient();
+    udpClient.Client.Bind(new IPEndPoint(IPAddress.Any, port));
+
+    var from = new IPEndPoint(0, 0);
+    while (true)
+    {
+        var recvBuffer = udpClient.Receive(ref from);
+        var payload = Encoding.UTF8.GetString(recvBuffer);
+        var parts = payload.Split(new char[] { DELIMITER });
+        string timestamp = DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss.fff");
+        Console.WriteLine($"{timestamp} - {parts[0]}: {parts[1].Trim()}");
+    }
+}
+catch (Exception ex)
+{
+    Console.WriteLine($"Error: {ex.Message}");
 }


### PR DESCRIPTION
Defaults to port 5100 for unchanged behaviour when no command line option entered. 

If single parameter on command line, try convert to port number and use in place of default. 

Enables running multiple instances of the UdpLogger Client on different port numbers for each Meadow. e.g. create multiple shortcuts and configure the command line parameter in each shortcut. 